### PR TITLE
Upgrade faraday to v2.5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,5 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 13.0"
-gem "faraday", "~> 1.8.0"
-gem "faraday_middleware", "~> 1.2.0"
+gem "faraday", "~> 2.5.2"
 gem "test-unit", "~> 3.5.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,16 @@
 PATH
   remote: .
   specs:
-    nordigen-ruby (1.0.1)
-      dotenv (~> 2.7.6)
-      faraday (~> 1.8.0)
-      faraday_middleware (~> 1.2.0)
+    nordigen-ruby (2.0.0)
+      faraday (~> 2.5.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    dotenv (2.7.6)
-    faraday (1.8.0)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0.1)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.1)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      multipart-post (>= 1.2, < 3)
+    faraday (2.5.2)
+      faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
-    multipart-post (2.1.1)
+    faraday-net_http (3.0.0)
     power_assert (2.0.1)
     rake (13.0.6)
     ruby2_keywords (0.0.5)
@@ -42,9 +21,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  dotenv (~> 2.7.6)
-  faraday (~> 1.8.0)
-  faraday_middleware (~> 1.2.0)
+  faraday (~> 2.5.2)
   nordigen-ruby!
   rake (~> 13.0)
   test-unit (~> 3.5.3)

--- a/lib/nordigen-ruby.rb
+++ b/lib/nordigen-ruby.rb
@@ -1,5 +1,4 @@
 require "faraday"
-require "faraday_middleware"
 
 require_relative "nordigen_ruby/api/institutions"
 require_relative "nordigen_ruby/api/agreements"

--- a/nordigen.gemspec
+++ b/nordigen.gemspec
@@ -33,8 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = `git ls-files -- bin/*`.split("\n")
                       .map { |f| ::File.basename(f) }
 
-  spec.add_dependency "faraday", "~> 1.8.0"
-  spec.add_dependency "faraday_middleware", "~> 1.2.0"
+  spec.add_dependency "faraday", "~> 2.5.2"
 
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
## Related Issue
This should solve #8.

## Proposed Changes
  * Simply upgrade faraday to v2.5.2
  * Remove faraday_middleware which has mostly been integrated into faraday

## Additional Info
I've also tried locally rebasing this on #9 just to verify that no additional tests fail after this change.
