### PR TITLE
fix Faraday initialization

### DIFF
--- a/lib/nordigen-ruby.rb
+++ b/lib/nordigen-ruby.rb
@@ -27,7 +27,7 @@ module Nordigen
             @requisition = RequisitionsApi.new(client=self)
         end
 
-        def request(params)
+        def request(params: {})
             # HTTP client request
             parameters = {}
             params.each do |key, value|
@@ -36,7 +36,7 @@ module Nordigen
                 end
             end
 
-            @request ||= Faraday.new do |conn|
+            Faraday.new(nil, params) do |conn|
                 conn.url_prefix = BASE_URL
                 conn.headers = @@headers
                 conn.request :json


### PR DESCRIPTION
## What is the issue
running `rails tests/tests.rb` yields the following errors (all tests fail)
```
[...]
E
======================================================================================================================
/Users/tobi/projects/nordigen-ruby/tests/test_requisitions.rb:14:in `setup'
/Users/tobi/projects/nordigen-ruby/lib/nordigen-ruby.rb:63:in `generate_token'
/Users/tobi/projects/nordigen-ruby/lib/nordigen-ruby.rb:30:in `request'
Error: test_get_requisitions(Nordigen::TestInstitutions): ArgumentError: wrong number of arguments (given 0, expected 1)
======================================================================================================================

Finished in 0.015956 seconds.
----------------------------------------------------------------------------------------------------------------------
19 tests, 0 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
0% passed
----------------------------------------------------------------------------------------------------------------------
1190.77 tests/s, 0.00 assertions/s
```

## Proposed Changes
1) set default value for params to fix all code locations where the parameters are empty
2) actually use the params on the Faraday init
3) no caching in instance variable to avoid one method call setting the params for another method call's Faraday request

## Additional Info
I can not verify that all tests are green after this change. I see some failures but I believe that is due to restrictions on my (free) API account.
