### PR TITLE
Fix date filter

### DIFF
--- a/lib/nordigen-ruby.rb
+++ b/lib/nordigen-ruby.rb
@@ -26,15 +26,8 @@ module Nordigen
             @requisition = RequisitionsApi.new(client=self)
         end
 
-        def request(params = nil)
+        def request
             # HTTP client request
-            parameters = {}
-            params&.each do |key, value|
-                if value
-                    parameters[key] = value
-                end
-            end
-
             @request ||= Faraday.new do |conn|
                 conn.url_prefix = BASE_URL
                 conn.headers = @@headers

--- a/lib/nordigen_ruby/api/account.rb
+++ b/lib/nordigen_ruby/api/account.rb
@@ -16,7 +16,7 @@ module Nordigen
                 url = "#{url}#{path}/"
             end
 
-            return client.request(params).get(url).body
+            return client.request.get(url, params).body
         end
 
         def get_metadata

--- a/tests/test_account.rb
+++ b/tests/test_account.rb
@@ -46,5 +46,9 @@ module Nordigen
             assert_equal(response["booked"], nil)
         end
 
+        def test_account_transactions_with_date_range
+            omit('Need a test account with enough transactions to filter by date to test this')
+        end
+
     end
 end


### PR DESCRIPTION
## Related Issue

https://github.com/nordigen/nordigen-ruby/issues/13

## Proposed Changes

Fixes so date range params are passed when fetching txs.

Previous code added the params at the wrong stage: When setting up the generic request function in Faraday. I think the params are supposed to be added when running the GET request, like they also are elsewhere in the code base (search for "params"). 

NB: Test is set as omitted, as I couldn't figure out if there were any txs to filter based on date. 

