### PR TITLE
Add user_language and account_selection params for requisition

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ init = client.init_session(
   # institution id
   institution_id: id,
   # a unique user ID of someone who's using your services, usually it's a UUID
-  reference_id: SecureRandom.uuid
+  reference_id: SecureRandom.uuid,
+  # A two-letter country code (ISO 639-1)
+  user_language: "en",
+  # option to enable account selection view for the end user
+  account_selection: true
 )
 
 link = init["link"] # bank authorization link

--- a/lib/nordigen-ruby.rb
+++ b/lib/nordigen-ruby.rb
@@ -77,7 +77,7 @@ module Nordigen
             return AccountApi.new(client: self, account_id: account_id)
         end
 
-        def init_session(redirect_url:, institution_id:, reference_id:, max_historical_days: 90)
+        def init_session(redirect_url:, institution_id:, reference_id:, max_historical_days: 90, user_language: "en", account_selection: false)
             # Factory method that creates authorization in a specific institution
             # and are responsible for the following steps:
             #   * Creates agreement
@@ -93,6 +93,8 @@ module Nordigen
                 redirect_url: redirect_url,
                 reference: reference_id,
                 institution_id: institution_id,
+                user_language: user_language,
+                account_selection: account_selection,
                 agreement: new_agreement["id"]
             )
 

--- a/lib/nordigen_ruby/api/requisitions.rb
+++ b/lib/nordigen_ruby/api/requisitions.rb
@@ -1,4 +1,3 @@
-
 module Nordigen
     class RequisitionsApi
 
@@ -10,14 +9,15 @@ module Nordigen
             @client = client
         end
 
-        def create_requisition(redirect_url:, reference:, institution_id:, user_language: "en", agreement: nil)
+        def create_requisition(redirect_url:, reference:, institution_id:, user_language: "en", agreement: nil, account_selection: false)
             # Create requisition. For creating links and retrieving accounts.
             payload = {
                 "redirect": redirect_url,
                 "reference": reference,
                 "institution_id": institution_id,
                 "user_language": user_language,
-            } 
+                "account_selection": account_selection,
+            }
 
             if agreement
                 payload["agreement"] = agreement

--- a/main.rb
+++ b/main.rb
@@ -30,7 +30,9 @@ module Nordigen
     init = client.init_session(
         redirect_url: "https://nordigen.com",
         institution_id: id,
-        reference_id: SecureRandom.uuid
+        reference_id: SecureRandom.uuid,
+        user_language: "en",
+        account_selection: true
     )
     requisition_id = init["id"]
     puts init["link"]


### PR DESCRIPTION
To follow up with this issue #17 
Aim is to be able to set `user_language` & `account_selection` options from session initializer
