### PR TITLE
Replace cdn URL

### DIFF
--- a/example/app/views/layouts/application.html.erb
+++ b/example/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
         <script src="https://unpkg.com/nordigen-bank-ui@1.3.0/package/src/selector.js"></script>
         <script>
             const config = {
-                redirectUrl: "https://www.nordigen.com",
+                redirectUrl: "https://gocardless.com",
                 logoUrl: 'https://cdn-logos.gocardless.com/ais/Nordigen_Logo_Black.svg',
                 text: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean mavdvd",
                 countryFilter: true,

--- a/example/app/views/layouts/application.html.erb
+++ b/example/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
         <script>
             const config = {
                 redirectUrl: "https://www.nordigen.com",
-                logoUrl: 'https://cdn.nordigen.com/ais/Nordigen_Logo_Black.svg',
+                logoUrl: 'https://cdn-logos.gocardless.com/ais/Nordigen_Logo_Black.svg',
                 text: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean mavdvd",
                 countryFilter: true,
                 styles: {


### PR DESCRIPTION
Updated `cdn.nordigen.com` to `cdn-logos.gocardless.com`, as nordigen.com domain will be deprecated.